### PR TITLE
Refactor mods to support more general data types

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ julia> b = Mod{9}(1)
 Mod{9}(1)
 
 julia> a+b
-ERROR: Cannot operate on two Mod objects with different moduli
+ERROR: can not promote types Mod{10,Int64} and Mod{9,Int64}
 ```
 
 
@@ -190,9 +190,6 @@ julia> reim(a)
 (Mod{10}(2), Mod{10}(7))
 ```
 
-
-
-
 #### Complex conjugate
 Use `a'` (or `conj(a)`) to get the complex conjugate value:
 ```julia
@@ -211,10 +208,10 @@ Mod{10}(4 + 0im)
 
 ### Inspection
 
-Given a `Mod` or `GaussMod` number, the modulus is recovered using the `modulus`
+Given a `Mod` number, the modulus is recovered using the `modulus`
 function and the numerical value with `value`:
 ```julia
-ulia> a = Mod{23}(100)
+julia> a = Mod{23}(100)
 Mod{23}(8)
 
 julia> modulus(a)
@@ -252,7 +249,7 @@ Mod{1000000000000000000}(0)
 ### Zeros and ones
 
 The standard Julia functions `zero`, `zeros`, `one`, and `ones` may be used
-with `Mod` and `GaussMod` types:
+with `Mod` types:
 ```julia
 julia> zero(Mod{9})
 Mod{9}(0)
@@ -271,11 +268,11 @@ julia> ones(GaussMod{5},4)
  Mod{5}(1 + 0im)
  Mod{5}(1 + 0im)
  Mod{5}(1 + 0im)
- ```
+```
 
 ### Random values
 
-The `rand` function can be used to produce random `Mod` or `GaussMod` values:
+The `rand` function can be used to produce random `Mod` values:
 ```julia
 julia> rand(Mod{17})
 Mod{17}(13)
@@ -313,11 +310,11 @@ problem as illustrated here with `a=3`, `m=10`, `b=5`, and `n=17`:
 julia> s = Mod{10}(3); t = Mod{17}(5);
 
 julia> CRT(s,t)
-Mod{170}(73)
+73
 ```
 
 We find that `mod(73,10)` equals `3` and `mod(73,17)` equals `5` as
-required. The answer is reported as `Mod{170}(73)` because any value of
+required. The answer is reported as `73` because any value of
 `x` congruent to 73 modulo 170 is a solution.
 
 The `CRT` function can be applied to any number of arguments so long

--- a/src/GaussMods.jl
+++ b/src/GaussMods.jl
@@ -46,7 +46,7 @@ reim(x::AbstractMod) = (real(x),imag(x))
 
 conj(x::GaussMod{N}) where N = GaussMod{N}(conj(x.val))
 
-function Mod{N,T}(x::GaussMod{N,T}) where {N,T}
+function Mod{N,T}(x::GaussMod{N,T2}) where {N,T<:Integer, T2<:Integer}
     if imag(x) == 0
         return Mod{N,T}(real(x))
     end 
@@ -93,16 +93,17 @@ isequal(x::GaussMod{N},y::GaussMod{N}) where N = value(x) == value(y)
 
 (/)(x::GaussMod{N}, y::GaussMod{N}) where N = x * inv(y)
 (//)(x::GaussMod{N}, y::GaussMod{N}) where N = x/y
-#(//)(x::Number, y::GaussMod{N}) where N = x/y
-#(//)(x::GaussMod{N}, y::Number) where N = x/y
+(//)(x::Number, y::GaussMod{N}) where N = x/y
+(//)(x::GaussMod{N}, y::Number) where N = x/y
 
 
 show(io::IO, z::GaussMod{N}) where N = print(io,"GaussMod{$N}($(value(z)))")
 show(io::IO, ::MIME"text/plain", z::GaussMod{N}) where N = show(io, z)
 
 # Random
-rand(::Type{GaussMod{N,T}}) where {N,T} = GaussMod{N}(rand(T) + im*rand(T))
-rand(::Type{GaussMod{N,T}}, dims::Integer...) where {N,T} = GaussMod{N}.(rand(T,dims...)) + im*GaussMod{N,T}.(rand(T,dims...))
+rand(::Type{GaussMod{N}}, args::Integer...) where {N} = rand(GaussMod{N,Int}, args...)
+rand(::Type{GaussMod{N,T}}) where {N,T<:Integer} = GaussMod{N,T}(rand(T) + im*rand(T))
+rand(::Type{GaussMod{N,T}}, dims::Integer...) where {N,T} = GaussMod{N,T}.(rand(T,dims...)) + im*GaussMod{N,T}.(rand(T,dims...))
 
 promote_rule(::Type{GaussMod{N,T}}, ::Type{Mod{N,T2}}) where {N,T,T2} = GaussMod{N,promote_type(T,T2)}
 promote_rule(::Type{GaussMod{N,T}}, ::Type{T2}) where {N, T, T2<:Integer} = GaussMod{N,promote_type(T,T2)}

--- a/src/GaussMods.jl
+++ b/src/GaussMods.jl
@@ -12,27 +12,29 @@ mod(z::Complex{<:Integer}, n::Integer) = Complex(mod(real(z), n), mod(imag(z), n
 struct GaussMod{N,T} <: AbstractMod
     val::Complex{T}
 end
+GaussMod{N,T}(x::Mod{N,T2}) where {N,T,T2} = GaussMod{N,T}(T(x.val))
 
 function GaussMod{N}(x::Complex{T}) where {T<:Integer, N}
     @assert N>1 "modulus must be at least 2"
-    GaussMod{N,T}(mod(x,N))
+    GaussMod{N,T}(x)
 end
 
 GaussMod(x::Complex{T}, N::Integer) where {T<:Integer} = GaussMod{N}(x)
 GaussMod{N}(x::S, y::T) where {N,S<:Integer,T<:Integer} = GaussMod{N}(x + y*im)
 GaussMod(x::Mod{N,T}) where {N,T} = GaussMod{N,T}(x.val)
-GaussMod{N,T}(x::Mod{N,T}) where {N,T} = GaussMod{N,T}(x.val)
 
-GaussMod{N}(x::Rational{T}) where {N,T<:Integer} = GaussMod{N,T}(numerator(x)) / GaussMod{N}(denominator(x))
-GaussMod{N}(x::Complex{Rational{T}}) where {N,T<:Integer} = GaussMod{N,T}(real(x)) + GaussMod{N}(imag(x))*im
+GaussMod{N}(x::Rational{T}) where {N,T<:Integer} = GaussMod{N,T}(numerator(x)) / GaussMod{N,T}(denominator(x))
+GaussMod{N}(x::Complex{Rational{T}}) where {N,T<:Integer} = GaussMod{N}(real(x)) + GaussMod{N}(imag(x))*im
 Base.zero(::Type{GaussMod{N,T}}) where {N,T} = GaussMod{N,T}(0+0im)
 Base.zero(::Type{GaussMod{N}}) where {N,T} = GaussMod{N,Int}(0+0im)
+
+modnumber(x::Complex, N::Integer) = GaussMod{N}(x)
 
 #Mod{N}(a::S,b::T) where {N,S<:Integer,T<:Integer} = GaussMod{N}(a+b*im)
 #Mod{N}(x::Complex) where N = GaussMod{N}(x)
 
-modulus(x::GaussMod{T}) where T = T
-value(a::GaussMod) = a.val
+modulus(x::GaussMod{N}) where N = N
+value(a::GaussMod{N}) where N = mod(a.val, N)
 
 real(x::GaussMod{N}) where N = Mod{N}(real(x.val))
 real(x::Mod) = x 
@@ -44,9 +46,9 @@ reim(x::AbstractMod) = (real(x),imag(x))
 
 conj(x::GaussMod{N}) where N = GaussMod{N}(conj(x.val))
 
-function Mod{N}(x::GaussMod{N}) where N
+function Mod{N,T}(x::GaussMod{N,T}) where {N,T}
     if imag(x) == 0
-        return Mod{N}(real(x))
+        return Mod{N,T}(real(x))
     end 
     error("Cannot convert $x to type Mod{$N} (nonzero imaginary part)\nPerhaps use: real(x)")
 end
@@ -56,24 +58,22 @@ Mod(x::GaussMod{N}) where N = Mod{N}(x)
 
 # ARITHMETIC
 
-function(+)(x::GaussMod{N}, y::GaussMod{N}) where N
+function(+)(x::GaussMod{N,T}, y::GaussMod{N,T}) where {N,T}
     xx = widen(x.val)
     yy = widen(y.val)
     zz = mod(xx+yy,N)
-    return Mod{N}(zz)
+    return GaussMod{N,T}(zz)
 end
 
 (-)(x::GaussMod{N}) where N = GaussMod{N}(-x.val)
 (-)(x::GaussMod{N},y::GaussMod{N}) where N = x + (-y)
 
-function (*)(x::GaussMod{N}, y::GaussMod{N}) where N
+function (*)(x::GaussMod{N,T}, y::GaussMod{N,T}) where {N,T}
     xx = widen(x.val)
     yy = widen(y.val)
     zz = mod(xx*yy,N)
-    return Mod{N}(zz)
+    return GaussMod{N,T}(zz)
 end
-
-
 
 function inv(x::GaussMod{N}) where N 
     try
@@ -88,39 +88,24 @@ function inv(x::GaussMod{N}) where N
 end
 
 is_invertible(x::GaussMod) = is_invertible(real(x*x'))
+==(x::GaussMod{N},y::GaussMod{N}) where N = isequal(x,y)
+isequal(x::GaussMod{N},y::GaussMod{N}) where N = value(x) == value(y)
 
 (/)(x::GaussMod{N}, y::GaussMod{N}) where N = x * inv(y)
-
 (//)(x::GaussMod{N}, y::GaussMod{N}) where N = x/y
-(//)(x::Number, y::GaussMod{N}) where N = x/y
-(//)(x::GaussMod{N}, y::Number) where N = x/y
+#(//)(x::Number, y::GaussMod{N}) where N = x/y
+#(//)(x::GaussMod{N}, y::Number) where N = x/y
 
 
-show(io::IO, z::GaussMod{N}) where N = print(io,"Mod{$N}($(z.val))")
-
-
+show(io::IO, z::GaussMod{N}) where N = print(io,"GaussMod{$N}($(value(z)))")
+show(io::IO, ::MIME"text/plain", z::GaussMod{N}) where N = show(io, z)
 
 # Random
-
 rand(::Type{GaussMod{N,T}}) where {N,T} = GaussMod{N}(rand(T) + im*rand(T))
 rand(::Type{GaussMod{N,T}}, dims::Integer...) where {N,T} = GaussMod{N}.(rand(T,dims...)) + im*GaussMod{N,T}.(rand(T,dims...))
 
-
-promote_rule(::Type{GaussMod{N,T}}, ::Type{Mod{N,T}}) where {N,T} = GaussMod{N,T}
-promote_rule(::Type{Mod{N,T}}, ::Type{GaussMod{N,T}}) where {N,T} = GaussMod{N,T}
-
-promote_rule(::Type{GaussMod{N,T}}, ::Type{T}) where {N, T} = GaussMod{N,T}
-promote_rule(::Type{T}, ::Type{GaussMod{N,T}}) where {N, T} = GaussMod{N,T}
-
-promote_rule(::Type{GaussMod{N,T}}, ::Type{Complex{T}}) where {N, T} = GaussMod{N,T}
-promote_rule(::Type{Complex{T}}, ::Type{GaussMod{N,T}}) where {N, T} = GaussMod{N,T}
-
-promote_rule(::Type{Mod{N,T}}, ::Type{Complex{T}}) where {N, T} = GaussMod{N,T}
-promote_rule(::Type{Complex{T}}, ::Type{Mod{N,T}}) where {N, T} = GaussMod{N,T}
-
-
-promote_rule(::Type{GaussMod{N,T}}, ::Type{Rational{T}}) where {N, T} = GaussMod{N,T}
-promote_rule(::Type{Rational{T}}, ::Type{GaussMod{N,T}}) where {N, T} = GaussMod{N,T}
-
-promote_rule(::Type{Mod{N,T}}, ::Type{T}) where {N, T<:Complex} = GaussMod{N,T}
-promote_rule(::Type{T}, ::Type{Mod{N,T}}) where {N, T<:Complex} = GaussMod{N,T}
+promote_rule(::Type{GaussMod{N,T}}, ::Type{Mod{N,T2}}) where {N,T,T2} = GaussMod{N,promote_type(T,T2)}
+promote_rule(::Type{GaussMod{N,T}}, ::Type{T2}) where {N, T, T2<:Integer} = GaussMod{N,promote_type(T,T2)}
+promote_rule(::Type{GaussMod{N,T}}, ::Type{Complex{T2}}) where {N, T, T2} = GaussMod{N,promote_type(T, T2)}
+promote_rule(::Type{GaussMod{N,T}}, ::Type{Rational{T2}}) where {N, T, T2} = GaussMod{N,promote_type(T, T2)}
+promote_rule(::Type{Mod{N,T}}, ::Type{Complex{T2}}) where {N, T,T2} = GaussMod{N,promote_type(T,T2)}

--- a/src/GaussMods.jl
+++ b/src/GaussMods.jl
@@ -5,6 +5,10 @@ export GaussMod, AbstractMod
 # mod support for Gaussian integers until officially adopted into Base
 mod(z::Complex{<:Integer}, n::Integer) = Complex(mod(real(z), n), mod(imag(z), n))
 
+"""
+`GaussMod{N,T}` is an alias of `Mod{N,Complex{T}}`.
+It is for computing Gaussian Modulus.
+"""
 const GaussMod{N,T} = Mod{N,Complex{T}}
 GaussMod{N}(x::T) where {N, T<:Integer} = Mod{N,Complex{T}}(x)
 GaussMod{N}(x::T) where {N, T<:Complex} = Mod{N,T}(x)

--- a/src/GaussMods.jl
+++ b/src/GaussMods.jl
@@ -5,59 +5,18 @@ export GaussMod, AbstractMod
 # mod support for Gaussian integers until officially adopted into Base
 mod(z::Complex{<:Integer}, n::Integer) = Complex(mod(real(z), n), mod(imag(z), n))
 
-"""
-`GaussMod{m,T}(v)` creates a modular number in mod `m` with value `mod(v,m)`.
-`GaussMod{m,T}()` is equivalent to `GaussMod{m}(0)`.
-"""
-struct GaussMod{N,T} <: AbstractMod
-    val::Complex{T}
-end
-GaussMod{N,T}(x::Mod{N,T2}) where {N,T,T2} = GaussMod{N,T}(T(x.val))
-
-function GaussMod{N}(x::Complex{T}) where {T<:Integer, N}
-    @assert N>1 "modulus must be at least 2"
-    GaussMod{N,T}(x)
-end
-
-GaussMod(x::Complex{T}, N::Integer) where {T<:Integer} = GaussMod{N}(x)
-GaussMod{N}(x::S, y::T) where {N,S<:Integer,T<:Integer} = GaussMod{N}(x + y*im)
-GaussMod(x::Mod{N,T}) where {N,T} = GaussMod{N,T}(x.val)
-
-GaussMod{N}(x::Rational{T}) where {N,T<:Integer} = GaussMod{N,T}(numerator(x)) / GaussMod{N,T}(denominator(x))
-GaussMod{N}(x::Complex{Rational{T}}) where {N,T<:Integer} = GaussMod{N}(real(x)) + GaussMod{N}(imag(x))*im
-Base.zero(::Type{GaussMod{N,T}}) where {N,T} = GaussMod{N,T}(0+0im)
-Base.zero(::Type{GaussMod{N}}) where {N,T} = GaussMod{N,Int}(0+0im)
-
-modnumber(x::Complex, N::Integer) = GaussMod{N}(x)
-
-#Mod{N}(a::S,b::T) where {N,S<:Integer,T<:Integer} = GaussMod{N}(a+b*im)
-#Mod{N}(x::Complex) where N = GaussMod{N}(x)
-
-modulus(x::GaussMod{N}) where N = N
-value(a::GaussMod{N}) where N = mod(a.val, N)
-
-real(x::GaussMod{N}) where N = Mod{N}(real(x.val))
-real(x::Mod) = x 
-
-imag(x::GaussMod{N}) where N = Mod{N}(imag(x.val))
-imag(x::Mod{N}) where N = Mod{N}(0)
+const GaussMod{N,T} = Mod{N,Complex{T}}
+GaussMod{N}(x::T) where {N, T<:Integer} = Mod{N,Complex{T}}(x)
+GaussMod{N}(x::T) where {N, T<:Complex} = Mod{N,T}(x)
+Mod{N}(x::Complex{Rational{T}}) where {N,T} = Mod{N}(real(x)) + Mod{N}(imag(x))*im
+Mod{N}(re::Integer, im::Integer) where N = Mod{N}(Complex(re, im))
 
 reim(x::AbstractMod) = (real(x),imag(x))
-
-conj(x::GaussMod{N}) where N = GaussMod{N}(conj(x.val))
-
-function Mod{N,T}(x::GaussMod{N,T2}) where {N,T<:Integer, T2<:Integer}
-    if imag(x) == 0
-        return Mod{N,T}(real(x))
-    end 
-    error("Cannot convert $x to type Mod{$N} (nonzero imaginary part)\nPerhaps use: real(x)")
-end
-
-Mod(x::GaussMod{N}) where N = Mod{N}(x)
-
+real(x::Mod{N}) where N = Mod{N}(real(x.val))
+imag(x::Mod{N}) where N = Mod{N}(imag(x.val))
+conj(x::Mod{N}) where N = Mod{N}(conj(x.val))
 
 # ARITHMETIC
-
 function(+)(x::GaussMod{N,T}, y::GaussMod{N,T}) where {N,T}
     xx = widen(x.val)
     yy = widen(y.val)
@@ -65,8 +24,7 @@ function(+)(x::GaussMod{N,T}, y::GaussMod{N,T}) where {N,T}
     return GaussMod{N,T}(zz)
 end
 
-(-)(x::GaussMod{N}) where N = GaussMod{N}(-x.val)
-(-)(x::GaussMod{N},y::GaussMod{N}) where N = x + (-y)
+(-)(x::GaussMod{N}) where N = Mod{N}(-x.val)
 
 function (*)(x::GaussMod{N,T}, y::GaussMod{N,T}) where {N,T}
     xx = widen(x.val)
@@ -88,25 +46,4 @@ function inv(x::GaussMod{N}) where N
 end
 
 is_invertible(x::GaussMod) = is_invertible(real(x*x'))
-==(x::GaussMod{N},y::GaussMod{N}) where N = isequal(x,y)
-isequal(x::GaussMod{N},y::GaussMod{N}) where N = value(x) == value(y)
-
-(/)(x::GaussMod{N}, y::GaussMod{N}) where N = x * inv(y)
-(//)(x::GaussMod{N}, y::GaussMod{N}) where N = x/y
-(//)(x::Number, y::GaussMod{N}) where N = x/y
-(//)(x::GaussMod{N}, y::Number) where N = x/y
-
-
-show(io::IO, z::GaussMod{N}) where N = print(io,"GaussMod{$N}($(value(z)))")
-show(io::IO, ::MIME"text/plain", z::GaussMod{N}) where N = show(io, z)
-
-# Random
-rand(::Type{GaussMod{N}}, args::Integer...) where {N} = rand(GaussMod{N,Int}, args...)
-rand(::Type{GaussMod{N,T}}) where {N,T<:Integer} = GaussMod{N,T}(rand(T) + im*rand(T))
-rand(::Type{GaussMod{N,T}}, dims::Integer...) where {N,T} = GaussMod{N,T}.(rand(T,dims...)) + im*GaussMod{N,T}.(rand(T,dims...))
-
-promote_rule(::Type{GaussMod{N,T}}, ::Type{Mod{N,T2}}) where {N,T,T2} = GaussMod{N,promote_type(T,T2)}
-promote_rule(::Type{GaussMod{N,T}}, ::Type{T2}) where {N, T, T2<:Integer} = GaussMod{N,promote_type(T,T2)}
-promote_rule(::Type{GaussMod{N,T}}, ::Type{Complex{T2}}) where {N, T, T2} = GaussMod{N,promote_type(T, T2)}
-promote_rule(::Type{GaussMod{N,T}}, ::Type{Rational{T2}}) where {N, T, T2} = GaussMod{N,promote_type(T, T2)}
-promote_rule(::Type{Mod{N,T}}, ::Type{Complex{T2}}) where {N, T,T2} = GaussMod{N,promote_type(T,T2)}
+rand(::Type{GaussMod{N}}, args::Integer...) where N = rand(GaussMod{N, Int}, args...)

--- a/src/Mods.jl
+++ b/src/Mods.jl
@@ -85,8 +85,12 @@ isequal(x::Mod{N,T1}, y::Mod{N,T2}) where {N,T1,T2} = value(x)==value(y)
 end
 
 
-function -(x::Mod{M,T}) where {M,T}
+function -(x::Mod{M,T}) where {M,T<:Signed}
     return Mod{M,T}(-x.val)  # Note: might break for UInt
+end
+
+function -(x::Mod{M,T}) where {M,T<:Unsigned}
+    return Mod{M,T}(M-value(x))
 end
 
 -(x::Mod,y::Mod) = x + (-y)
@@ -119,7 +123,8 @@ This may be abbreviated by `x'`.
 @inline function inv(x::Mod{M,T}) where {M,T}
     Mod{M,T}(_invmod(x.val, M))
 end
-@inline function _invmod(x, m)
+_invmod(x::Unsigned, m::Unsigned) = invmod(x, m)
+@inline function _invmod(x::Signed, m::Signed)
     (g, v, _) = gcdx(x, m)
     if g != 1
         error("$x (mod $m) is not invertible")

--- a/src/Mods.jl
+++ b/src/Mods.jl
@@ -1,11 +1,11 @@
 module Mods
 
-import Base: isequal, (==), (+), (-), (*), (inv), (/), (//), (^), hash, show
-import Base: zero, one, rand, conj
+import Base: (==), (+), (-), (*), (inv), (/), (//), (^), hash, show
+import Base: rand, conj
 
 export Mod, modulus, value, AbstractMod
-export isequal, ==, +, -, *, is_invertible, inv, /, ^
-export hash, CRT
+export is_invertible
+export CRT
 
 abstract type AbstractMod <: Number end
 
@@ -51,12 +51,6 @@ julia> value(a)
 """
 value(a::Mod{N}) where N = mod(a.val, N)
 
-zero(::Mod{N,T}) where {N,T} = Mod{N,T}(zero(T))
-zero(::Type{Mod{N,T}}) where {N,T} = Mod{N,T}(zero(T))
-
-one(::Mod{N,T}) where {N,T} = Mod{N,T}(one(T))
-one(::Type{Mod{N,T}}) where {N,T} = Mod{N,T}(one(T))
-
 function hash(x::Mod, h::UInt64= UInt64(0))
     v = value(x)
     m = modulus(x)
@@ -64,11 +58,8 @@ function hash(x::Mod, h::UInt64= UInt64(0))
 end
 
 # Test for equality
-isequal(x::Mod{N,T1}, y::Mod{M,T2}) where {M,N,T1,T2} = false
-isequal(x::Mod{N,T1}, y::Mod{N,T2}) where {N,T1,T2} = value(x)==value(y)
-
-==(x::Mod,y::Mod) = isequal(x,y)
-
+==(x::Mod{N,T1}, y::Mod{M,T2}) where {M,N,T1,T2} = false
+==(x::Mod{N,T1}, y::Mod{N,T2}) where {N,T1,T2} = value(x)==value(y)
 
 # Easy arithmetic
 @inline function +(x::Mod{N,T}, y::Mod{N,T}) where {N,T}
@@ -136,7 +127,7 @@ end
 (//)(x::Number, y::Mod{N}) where N = x/y
 (//)(x::Mod{N}, y::Number) where N = x/y
 
-Base.promote_rule(::Type{Mod{M,T1}}, ::Type{Mod{N,T2}}) where {M,N,T1,T2<:Number} = error("can not promote types Mod{$M,$T1} and Mod{$N,$T2}")
+Base.promote_rule(::Type{Mod{M,T1}}, ::Type{Mod{N,T2}}) where {M,N,T1,T2<:Number} = error("can not promote types `Mod{$M,$T1}`` and `Mod{$N,$T2}`")
 Base.promote_rule(::Type{Mod{M,T1}}, ::Type{Mod{M,T2}}) where {M,T1,T2<:Number} = Mod{M,promote_type(T1, T2)}
 Base.promote_rule(::Type{Mod{M,T1}}, ::Type{T2}) where {M,T1,T2<:Number} = Mod{M,promote_type(T1, T2)}
 Base.promote_rule(::Type{Mod{M,T1}}, ::Type{Rational{T2}}) where {M,T1,T2} = Mod{M,promote_type(T1, T2)}
@@ -144,20 +135,6 @@ Base.promote_rule(::Type{Mod{M,T1}}, ::Type{Rational{T2}}) where {M,T1,T2} = Mod
 # Operations with rational numbers  
 Mod{N}(k::Rational) where N = Mod{N}(numerator(k))/Mod{N}(denominator(k))
 Mod{N,T}(k::Rational{T2}) where {N,T,T2} = Mod{N,T}(numerator(k))/Mod{N,T}(denominator(k))
-
-# Comparison with Integers, Complex et al
-isequal(x::Mod{M}, k::Number) where M = mod(k,M) == value(x)
-isequal(k::Number, x::Mod) = isequal(x,k)
-(==)(x::Mod, k::Number) = isequal(x,k)
-(==)(k::Number, x::Mod) = isequal(x,k)
-
-# Comparisons with Rationals
-function isequal(x::Mod{N}, k::Rational) where N
-    return x == Mod{N}(k)
-end
-isequal(k::Rational,x::Mod) = isequal(x,k)
-(==)(x::Mod, k::Rational) = isequal(x,k)
-(==)(k::Rational, x::Mod) = isequal(x,k)
 
 # Random
 rand(::Type{Mod{N}}, args::Integer...) where {N} = rand(Mod{N,Int}, args...)

--- a/src/Mods.jl
+++ b/src/Mods.jl
@@ -1,7 +1,7 @@
 module Mods
 
 import Base: (==), (+), (-), (*), (inv), (/), (//), (^), hash, show
-import Base: rand, conj
+import Base: rand, conj, iszero
 
 export Mod, modulus, value, AbstractMod
 export is_invertible
@@ -58,9 +58,9 @@ function hash(x::Mod, h::UInt64= UInt64(0))
 end
 
 # Test for equality
+iszero(x::Mod{N,T}) where {N,T} = iszero(mod(x.val, N))
 ==(x::Mod{N,T1}, y::Mod{M,T2}) where {M,N,T1,T2} = false
-==(x::Mod{N,T1}, y::Mod{N,T2}) where {N,T1,T2} = value(x) == value(y)
-==(x::Mod{N,T1}, y::Mod{N,T2}) where {N,T1<:Signed,T2} = iszero(mod(x.val - y.val, N))
+==(x::Mod{N,T1}, y::Mod{N,T2}) where {N,T1,T2} = iszero(value(x - y))
 
 # Easy arithmetic
 @inline function +(x::Mod{N,T}, y::Mod{N,T}) where {N,T}

--- a/src/Mods.jl
+++ b/src/Mods.jl
@@ -59,7 +59,8 @@ end
 
 # Test for equality
 ==(x::Mod{N,T1}, y::Mod{M,T2}) where {M,N,T1,T2} = false
-==(x::Mod{N,T1}, y::Mod{N,T2}) where {N,T1,T2} = iszero(x - y)
+==(x::Mod{N,T1}, y::Mod{N,T2}) where {N,T1,T2} = value(x) == value(y)
+==(x::Mod{N,T1}, y::Mod{N,T2}) where {N,T1<:Signed,T2} = iszero(mod(x.val - y.val, N))
 
 # Easy arithmetic
 @inline function +(x::Mod{N,T}, y::Mod{N,T}) where {N,T}

--- a/src/Mods.jl
+++ b/src/Mods.jl
@@ -129,6 +129,8 @@ function /(x::Mod{N,T}, y::Mod{N,T}) where {N,T}
 end
 
 (//)(x::Mod,y::Mod) = x/y
+(//)(x::Number, y::Mod{N}) where N = x/y
+(//)(x::Mod{N}, y::Number) where N = x/y
 
 #Base.convert(::Type{Mod{M,T}}, x::Integer) where {M,T} = Mod{M,T}(x)
 Base.promote_rule(::Type{Mod{M,T1}}, ::Type{T2}) where {M,T1<:Integer,T2<:Integer} = Mod{M,promote_type(T1, T2)}
@@ -161,8 +163,9 @@ isequal(k::Rational,x::Mod) = isequal(x,k)
 
 # Random
 
-rand(::Type{Mod{N}}) where N = Mod{N}(rand(Int))
-rand(::Type{Mod{N}},dims::Integer...) where N = Mod{N}.(rand(Int,dims...))
+rand(::Type{Mod{N}}, args::Integer...) where {N} = rand(Mod{N,Int}, args...)
+rand(::Type{Mod{N,T}}) where {N,T} = Mod{N}(rand(T))
+rand(::Type{Mod{N,T}},dims::Integer...) where {N,T} = Mod{N}.(rand(T,dims...))
 
 
 
@@ -170,8 +173,6 @@ rand(::Type{Mod{N}},dims::Integer...) where N = Mod{N}.(rand(Int,dims...))
 
 # private helper function
 function CRT_work(x::Mod{n}, y::Mod{m}) where {n,m}
-    # n = x.mod
-    # m = y.mod
     if gcd(n,m) != 1
         error("Moduli must be pairwise relatively prime")
     end
@@ -179,11 +180,11 @@ function CRT_work(x::Mod{n}, y::Mod{m}) where {n,m}
     a = x.val
     b = y.val
 
-    k = inv(Mod(n,m)) * (b-a)
+    k = inv(Mod{m}(n)) * (b-a)
 
     z = a + k.val*n
 
-    return Mod(z, n*m)
+    return Mod{n*m}(z)
 end
 
 # public interface

--- a/src/Mods.jl
+++ b/src/Mods.jl
@@ -151,7 +151,7 @@ rand(::Type{Mod{N,T}},dims::Integer...) where {N,T} = Mod{N}.(rand(T,dims...))
 Chinese Remainder Theorem.
 
 ```
-julia> CRT(Mod{11}(4), Mod{14}(814))
+julia> CRT(Int, Mod{11}(4), Mod{14}(814))
 92
 
 julia> 92%11
@@ -160,7 +160,8 @@ julia> 92%11
 julia> 92%14
 8
 
-julia> CRT(BigInt, Mod{9223372036854775783}(9223372036854775782), Mod{9223372036854775643}(9223372036854775642))
+julia> CRT(Mod{9223372036854775783}(9223372036854775782), Mod{9223372036854775643}(9223372036854775642))
+85070591730234614113402964855534653468
 ```
 
 !!! note
@@ -169,17 +170,18 @@ julia> CRT(BigInt, Mod{9223372036854775783}(9223372036854775782), Mod{9223372036
     If you are confident that numbers does not overflow in your application,
     please specify an optional type parameter as the first argument.
 """
-function CRT(remainders, primes) where T
+function CRT(::Type{T}, remainders, primes) where T
     length(remainders) == length(primes) || error("size mismatch")
-    isempty(remainders) && throw(ArgumentError("input arguments should not be empty."))
+    isempty(remainders) && return zero(T)
+    primes = convert.(T, primes)
     M = prod(primes)
     Ms = M .÷ primes
     ti = _invmod.(Ms, primes)
-    mod(sum(remainders .* ti .* Ms), M)
+    mod(sum(convert.(T, remainders) .* ti .* Ms), M)
 end
 
 function CRT(::Type{T}, rs::Mod...) where T
-    CRT(convert.(T, value.(rs)), convert.(T, modulus.(rs)))
+    CRT(T, value.(rs), modulus.(rs))
 end
 CRT(rs::Mod...) = CRT(BigInt, rs...)
 

--- a/src/Mods.jl
+++ b/src/Mods.jl
@@ -59,8 +59,7 @@ end
 
 # Test for equality
 ==(x::Mod{N,T1}, y::Mod{M,T2}) where {M,N,T1,T2} = false
-==(x::Mod{N,T1}, y::Mod{N,T2}) where {N,T1,T2} = value(x) == value(y)
-==(x::Mod{N,T1}, y::Mod{N,T2}) where {N,T1<:Signed,T2} = iszero(mod(x.val - y.val, N))
+==(x::Mod{N,T1}, y::Mod{N,T2}) where {N,T1,T2} = iszero(x - y)
 
 # Easy arithmetic
 @inline function +(x::Mod{N,T}, y::Mod{N,T}) where {N,T}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -153,7 +153,7 @@ end
     a = Mod{p}(17)
     b = Mod{q}(32)
 
-    @test_throws ArgumentError CRT([], [])
+    @test CRT(Int32, [], []) === Int32(0)
     x = CRT(a, b)
     @test typeof(x) <: BigInt
     @test a == mod(x, p)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -155,11 +155,13 @@ end
 
     @test_throws ArgumentError CRT([], [])
     x = CRT(a, b)
+    @test typeof(x) <: BigInt
     @test a == mod(x, p)
     @test b == mod(x, q)
 
     c = Mod{101}(86)
-    x = CRT(a,b,c)
+    x = CRT(Int, a,b,c)
+    @test typeof(x) <: Int
 
     @test a == mod(x, p)
     @test b == mod(x, q)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using Test
 using Mods
 
 @testset "Constructors" begin 
-    @test Mod{17}() == 0
+    @test zero(Mod{17}) == 0
     @test Mod{17}(1) == GaussMod{17}(1,0)
     @test GaussMod{17}(1,2) == 1 + 2im
     a = Mod{17}(3)
@@ -46,12 +46,12 @@ end
     b = GaussMod{p}(5 + 5im)
 
     @test a + b == 8 + 4im
-    @test a + Mod{p}(11) == Mod{p}(14, 22)
+    @test a + Mod{p}(11) == GaussMod{p}(14, 22)
     @test -a == 20 + im
-    @test a - b == Mod{p}(3 - im - 5 - 5im)
+    @test a - b == modnumber(3 - im - 5 - 5im, p)
 
-    @test a * b == Mod{p}((3 - im) * (5 + 5im))
-    @test a / b == Mod{p}((3 - im) // (5 + 5im))
+    @test a * b == modnumber((3 - im) * (5 + 5im), p)
+    @test a / b == modnumber((3 - im) // (5 + 5im), p)
 
     @test a^(p * p - 1) == 1
     @test is_invertible(a)
@@ -59,12 +59,6 @@ end
 
     @test a / (1 + im) == a / GaussMod{p}(1 + im)
     @test imag(a * a') == 0
-
-
-
-
-
-
 end
 
 @testset "Large Modulus" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,7 +82,7 @@ end
     @test p - x == x - 2x
 
     p = 9223372036854775783   # This is a large prime
-    x = Mod{p}(-2 + 0im)
+    x = GaussMod{p}(-2 + 0im)
     @test x * x == 4
     @test x + x == -4
     @test x / x == 1
@@ -151,7 +151,7 @@ end
     @test length(A) == 1
 
     v = [Mod{10}(t) for t = 1:15]
-    w = [Mod{10}(t + 0im) for t = 1:15]
+    w = [GaussMod{10}(t + 0im) for t = 1:15]
     S = Set(v)
     T = Set(w)
     @test length(S) == 10

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,10 @@ using Test
 using Mods
 
 @testset "Constructors" begin 
+    @test one(Mod{17}) == Mod{17}(1)
+    @test oneunit(Mod{17}) == Mod{17}(1)
     @test zero(Mod{17}) == 0
+    @test iszero(zero(Mod{17}))
     @test Mod{17}(1) == Mod{17}(1,0)
     @test Mod{17}(1,2) == 1 + 2im
     a = Mod{17}(3)
@@ -11,6 +14,8 @@ using Mods
     @test typeof(a) == GaussMod{17,Int}
     a = zero(Mod{17})
     @test typeof(a) == Mod{17,Int}
+    a = Mod{17}(1//2 + (3//4)im)
+    @test typeof(a) == GaussMod{17,Int}
 end 
 
 
@@ -41,6 +46,8 @@ end
 
     @test Mod{p}(3//7) == 3//7
     @test isequal(3//7,  Mod{p}(3//7))
+
+    @test -Mod{13,Int}(typemin(Int)) == -Mod{13}(mod(typemin(Int), 13))
 end
 
 @testset "Mod arithmetic with UInt" begin
@@ -77,7 +84,7 @@ end
     @test rand(GaussMod{6}) isa GaussMod
     @test eltype(rand(GaussMod{6}, 4, 4)) <: GaussMod
     p = 23
-    a = Mod{p}(3 - im)
+    a = GaussMod{p}(3 - im)
     b = Mod{p}(5 + 5im)
 
     @test a + b == 8 + 4im
@@ -146,6 +153,7 @@ end
     a = Mod{p}(17)
     b = Mod{q}(32)
 
+    @test_throws ArgumentError CRT([], [])
     x = CRT(a, b)
     @test a == mod(x, p)
     @test b == mod(x, q)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -112,16 +112,17 @@ end
     b = Mod{q}(32)
 
     x = CRT(a, b)
-    @test a == mod(value(x), p)
-    @test b == mod(value(x), q)
+    @test a == mod(x, p)
+    @test b == mod(x, q)
 
     c = Mod{101}(86)
     x = CRT(a,b,c)
 
-    @test a == mod(value(x), p)
-    @test b == mod(value(x), q)
-    @test c == mod(value(x), 101)
+    @test a == mod(x, p)
+    @test b == mod(x, q)
+    @test c == mod(x, 101)
 
+    @test  CRT(BigInt, Mod{9223372036854775783}(9223372036854775782), Mod{9223372036854775643}(9223372036854775642)) == 85070591730234614113402964855534653468
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,32 @@ end
     @test a^(-1) == inv(a)
 end
 
+@testset "Mod arithmetic with UInt" begin
+    p = UInt(23)
+    a = Mod{p,UInt}(2)
+    b = Mod{p,UInt}(25)
+    @test a == b
+    @test a == 2
+    @test a == -21
+
+    b = Mod{p,UInt}(20)
+    @test a + b == 22
+    @test a - b == -18
+    @test a + a == 2a
+    @test 0 - a == -a
+
+    @test a * b == Mod{p,UInt}(17)
+    @test (a / b) * b == a
+    @test (b // a) * (2 // 1) == b
+    @test a * (2 // 3) == (2a) * inv(Mod{p,UInt}(3))
+
+    @test is_invertible(a)
+    @test !is_invertible(Mod{10,UInt}(4))
+
+    @test a^(p - 1) == 1
+    @test a^(-1) == inv(a)
+end
+
 @testset "GaussMod arithmetic" begin
     p = 23
     a = GaussMod{p}(3 - im)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,13 +4,13 @@ using Mods
 @testset "Constructors" begin 
     @test Mod{17}() == 0
     @test Mod{17}(1) == GaussMod{17}(1,0)
-    @test Mod{17}(1,2) == 1 + 2im
+    @test GaussMod{17}(1,2) == 1 + 2im
     a = Mod{17}(3)
-    @test typeof(a) == Mod{17}
-    a = Mod{17}(3,2)
-    @test typeof(a) == GaussMod{17}
-    a = GaussMod{17}()
-    @test typeof(a) == GaussMod{17}
+    @test typeof(a) == Mod{17,Int}
+    a = GaussMod{17}(3,2)
+    @test typeof(a) == GaussMod{17,Int}
+    a = zero(GaussMod{17})
+    @test typeof(a) == GaussMod{17,Int}
 end 
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,6 +38,9 @@ end
 
     @test a^(p - 1) == 1
     @test a^(-1) == inv(a)
+
+    @test Mod{p}(3//7) == 3//7
+    @test isequal(3//7,  Mod{p}(3//7))
 end
 
 @testset "Mod arithmetic with UInt" begin
@@ -46,11 +49,11 @@ end
     b = Mod{p,UInt}(25)
     @test a == b
     @test a == 2
-    @test a == -21
+    @test a == 25
 
     b = Mod{p,UInt}(20)
     @test a + b == 22
-    @test a - b == -18
+    @test a - b == 28
     @test a + a == 2a
     @test 0 - a == -a
 
@@ -191,5 +194,3 @@ end
     @test S == T
     @test union(S, T) == intersect(S, T)
 end
-
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,14 +3,14 @@ using Mods
 
 @testset "Constructors" begin 
     @test zero(Mod{17}) == 0
-    @test Mod{17}(1) == GaussMod{17}(1,0)
-    @test GaussMod{17}(1,2) == 1 + 2im
+    @test Mod{17}(1) == Mod{17}(1,0)
+    @test Mod{17}(1,2) == 1 + 2im
     a = Mod{17}(3)
     @test typeof(a) == Mod{17,Int}
-    a = GaussMod{17}(3,2)
+    a = Mod{17}(3,2)
     @test typeof(a) == GaussMod{17,Int}
-    a = zero(GaussMod{17})
-    @test typeof(a) == GaussMod{17,Int}
+    a = zero(Mod{17})
+    @test typeof(a) == Mod{17,Int}
 end 
 
 
@@ -60,30 +60,36 @@ end
     @test a * (2 // 3) == (2a) * inv(Mod{p,UInt}(3))
 
     @test is_invertible(a)
-    @test !is_invertible(Mod{10,UInt}(4))
+    @test !is_invertible(Mod{10}(4))
 
     @test a^(p - 1) == 1
     @test a^(-1) == inv(a)
 end
 
 @testset "GaussMod arithmetic" begin
+    @test one(GaussMod{6}) == Mod{6}(1+0im)
+    @test zero(GaussMod{6}) == Mod{6}(0+0im)
+    @test GaussMod{6}(2 + 3im) == Mod{6}(2+3im)
+    @test GaussMod{6,Int}(2 + 3im) == Mod{6}(2+3im)
+    @test rand(GaussMod{6}) isa GaussMod
+    @test eltype(rand(GaussMod{6}, 4, 4)) <: GaussMod
     p = 23
-    a = GaussMod{p}(3 - im)
-    b = GaussMod{p}(5 + 5im)
+    a = Mod{p}(3 - im)
+    b = Mod{p}(5 + 5im)
 
     @test a + b == 8 + 4im
-    @test a + Mod{p}(11) == GaussMod{p}(14, 22)
+    @test a + Mod{p}(11) == Mod{p}(14, 22)
     @test -a == 20 + im
-    @test a - b == modnumber(3 - im - 5 - 5im, p)
+    @test a - b == Mod{p}(3 - im - 5 - 5im)
 
-    @test a * b == modnumber((3 - im) * (5 + 5im), p)
-    @test a / b == modnumber((3 - im) // (5 + 5im), p)
+    @test a * b == Mod{p}((3 - im) * (5 + 5im))
+    @test a / b == Mod{p}((3 - im) // (5 + 5im))
 
     @test a^(p * p - 1) == 1
     @test is_invertible(a)
     @test a * inv(a) == 1
 
-    @test a / (1 + im) == a / GaussMod{p}(1 + im)
+    @test a / (1 + im) == a / Mod{p}(1 + im)
     @test imag(a * a') == 0
 end
 
@@ -108,7 +114,7 @@ end
     @test p - x == x - 2x
 
     p = 9223372036854775783   # This is a large prime
-    x = GaussMod{p}(-2 + 0im)
+    x = Mod{p}(-2 + 0im)
     @test x * x == 4
     @test x + x == -4
     @test x / x == 1
@@ -159,7 +165,7 @@ end
     M = ones(Mod{11}, 5, 5)
     @test sum(M) == 3
 
-    M = rand(GaussMod{11}, 5, 6)
+    M = rand(Mod{11}, 5, 6)
     @test size(M) == (5, 6)
 
     A = rand(Mod{17}, 5, 5)
@@ -178,7 +184,7 @@ end
     @test length(A) == 1
 
     v = [Mod{10}(t) for t = 1:15]
-    w = [GaussMod{10}(t + 0im) for t = 1:15]
+    w = [Mod{10}(t + 0im) for t = 1:15]
     S = Set(v)
     T = Set(w)
     @test length(S) == 10


### PR DESCRIPTION
Nice package, I did some changes to fit my using case. List of changes are,
* add a second type parameter to Mod, so that `UInt` can be used in computing, `GaussMod{N,T}` is now an alias of `Mod{N,Complex{T}}`, so that a lot code can be reused.
* improve the performance of `Mod` algebra a lot.
* Clean up codes
    * use promotion instead of redefining algebras with integers and rationals.
* make CRT compatible with big integers, so that one does not suffer from integer overflow when using CRT to compute extremely big numbers. One the otherside, it will not return the modulus anymore, because the modulus can sometimes be a BigInt, which is not a valid type parameter.
* update documentations and README.

Looking forward to your review.