### PR TITLE
Support isapprox to fix interaction with Polynomials.jl

### DIFF
--- a/src/Mods.jl
+++ b/src/Mods.jl
@@ -1,7 +1,7 @@
 module Mods
 
 import Base: (==), (+), (-), (*), (inv), (/), (//), (^), hash, show
-import Base: rand, conj, iszero
+import Base: rand, conj, iszero, rtoldefault, isapprox
 
 export Mod, modulus, value, AbstractMod
 export is_invertible
@@ -60,9 +60,14 @@ function hash(x::Mod, h::UInt64 = UInt64(0))
 end
 
 # Test for equality
-iszero(x::Mod{N,T}) where {N,T} = iszero(mod(x.val, N))
-==(x::Mod{N,T1}, y::Mod{M,T2}) where {M,N,T1,T2} = false
-==(x::Mod{N,T1}, y::Mod{N,T2}) where {N,T1,T2} = iszero(value(x - y))
+iszero(x::Mod{N}) where N = iszero(mod(x.val, N))
+==(x::Mod, y::Mod) = false
+==(x::Mod{N}, y::Mod{N}) where N = iszero(value(x - y))
+
+# Apporximate equality
+rtoldefault(::Type{Mod{N, T}}) where {N, T} = rtoldefault(T)
+isapprox(x::Mod, y::Mod; kwargs...) = false
+isapprox(x::Mod{N}, y::Mod{N}; kwargs...) where N = isapprox(value(x), value(y); kwargs...) || isapprox(value(y), value(x); kwargs...)
 
 # Easy arithmetic
 @inline function +(x::Mod{N,T}, y::Mod{N,T}) where {N,T}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -226,3 +226,13 @@ end
     @test A * x == b
     @test inv(A) * b == x
 end
+
+@testset "isapprox" begin
+    @test Mod{7}(3) ≈ Mod{7}(3)
+    @test Mod{7}(3) ≈ Mod{7}(10)
+    @test Mod{7}(3) ≈ Mod{7}(10) atol=1
+    @test Mod{7}(3) ≈ Mod{7}(11) atol=1
+    @test !isapprox(Mod{7}(3), Mod{7}(11), atol=0)
+    @test !(Mod{7}(3) ≈ Mod{7}(11))
+    @test Mod{7}(3) ≈ Mod{7}(11) atol=2
+end


### PR DESCRIPTION
Before:
```julia
julia> using Polynomials, Mods

julia> Mod{5}(1) ≈ Mod{5}(2)
ERROR: MethodError: no method matching rtoldefault(::Type{Mod{5, Int64}})
Closest candidates are:
  rtoldefault(::Union{Type{T}, T}, ::Union{Type{S}, S}, ::Real) where {T<:Number, S<:Number} at floatfuncs.jl:329
  rtoldefault(::Type{T}) where T<:AbstractFloat at floatfuncs.jl:327
  rtoldefault(::Type{<:Real}) at floatfuncs.jl:328
Stacktrace:
 [1] rtoldefault(x::Mod{5, Int64}, y::Mod{5, Int64}, atol::Int64)
   @ Base ./floatfuncs.jl:330
 [2] isapprox(x::Mod{5, Int64}, y::Mod{5, Int64})
   @ Base ./floatfuncs.jl:300
 [3] top-level scope
   @ REPL[85]:1

julia> Polynomial([Mod{5}(1)]) ÷ Polynomial([Mod{5}(2)])
ERROR: MethodError: no method matching rtoldefault(::Type{Mod{5, Int64}})
Closest candidates are:
  rtoldefault(::Union{Type{T}, T}, ::Union{Type{S}, S}, ::Real) where {T<:Number, S<:Number} at floatfuncs.jl:329
  rtoldefault(::Type{T}) where T<:AbstractFloat at floatfuncs.jl:327
  rtoldefault(::Type{<:Real}) at floatfuncs.jl:328
Stacktrace:
 [1] rtoldefault(x::Mod{5, Int64}, y::Int64, atol::Int64)
   @ Base ./floatfuncs.jl:330
 [2] isapprox(x::Mod{5, Int64}, y::Int64)
   @ Base ./floatfuncs.jl:300
 [3] divrem(num::Polynomial{Mod{5, Int64}, :x}, den::Polynomial{Mod{5, Int64}, :x})
   @ Polynomials ~/.julia/dev/Polynomials/src/polynomials/standard-basis.jl:234
 [4] div(n::Polynomial{Mod{5, Int64}, :x}, d::Polynomial{Mod{5, Int64}, :x})
   @ Polynomials ~/.julia/dev/Polynomials/src/common.jl:1121
 [5] top-level scope
   @ REPL[86]:1
```
after:
```julia
julia> Mod{5}(1) ≈ Mod{5}(2)
false

julia> Polynomial([Mod{5}(1)]) ÷ Polynomial([Mod{5}(2)])
Polynomial(Mod{5}(3))
```